### PR TITLE
Add getClassName method to DependencyInjection

### DIFF
--- a/src/DependencyInjection.php
+++ b/src/DependencyInjection.php
@@ -58,6 +58,24 @@ class DependencyInjection
     }
 
     /**
+     * @return string
+     */
+    public function getClassName(): string
+    {
+        if ($this->use) {
+            if ($this->class instanceof Param) {
+                return $this->class->getParam();
+            }
+            return $this->class;
+        }
+        $class = $this->getClass();
+        if ($class instanceof Param) {
+            return $class->getParam();
+        }
+        return $class;
+    }
+
+    /**
      * @param mixed $class
      * @throws DependencyInjectionException
      */

--- a/src/DependencyInjection.php
+++ b/src/DependencyInjection.php
@@ -62,17 +62,8 @@ class DependencyInjection
      */
     public function getClassName(): string
     {
-        if ($this->use) {
-            if ($this->class instanceof Param) {
-                return $this->class->getParam();
-            }
-            return $this->class;
-        }
         $class = $this->getClass();
-        if ($class instanceof Param) {
-            return $class->getParam();
-        }
-        return $class;
+        return ($class instanceof Param) ? $class->getParam() : $class;
     }
 
     /**

--- a/tests/DependencyInjectionTest.php
+++ b/tests/DependencyInjectionTest.php
@@ -390,4 +390,29 @@ class DependencyInjectionTest extends TestCase
         $this->assertEquals(24, $injectedLegacy->calculate());
     }
 
+    /**
+     * Test for the getClassName() method
+     * 
+     * @throws DependencyInjectionException
+     * @throws ConfigNotFoundException
+     * @throws ConfigException
+     * @throws KeyNotFoundException
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    public function testGetClassName()
+    {
+        $config = $this->object->build('di-test');
+
+        // Test when $use is false (using bind)
+        $di = $config->get("Random2");
+        $this->assertInstanceOf(DependencyInjection::class, $di);
+        $this->assertEquals(Random::class, $di->getClassName());
+
+        // Test when $use is true (using use)
+        // The 'Value' key is defined with DI::use(Area::class)
+        $value = $config->raw('Value');
+        $this->assertInstanceOf(DependencyInjection::class, $value);
+        $this->assertEquals(Area::class, $value->getClassName());
+    }
 }


### PR DESCRIPTION
This pull request introduces a new `getClassName` method to the `DependencyInjection` class. This method facilitates improved access to class names, enhancing code readability and maintainability.

No issues are linked to this pull request.  

### Added
- `DependencyInjection`: Added `getClassName` method.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add `getClassName` method to `DependencyInjection` class and corresponding unit tests to verify its functionality.

### Why are these changes being made?

The `getClassName` method is introduced to retrieve the class name, accounting for different configurations of the class, such as when `use` is true or false. This addition provides a more flexible and standardized way to access class names within the Dependency Injection framework, enhancing its usability and simplifying the process for consumers to get class names.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->